### PR TITLE
Fix rover_bringup launch file glob paths

### DIFF
--- a/src/rover_bringup/setup.py
+++ b/src/rover_bringup/setup.py
@@ -3,8 +3,15 @@ import os
 from glob import glob
 
 package_name = 'rover_bringup'
-launch_files = glob(os.path.join('rover_bringup','launch', '*.launch.py'))
-config_files = glob(os.path.join('rover_bringup','config', '*.yaml'))
+# Search for launch files placed directly in the package's ``launch`` directory
+# rather than under an additional ``rover_bringup`` subdirectory.  This aligns
+# the installation paths with the typical ROS 2 layout where launch files are
+# located at the top level of the package.
+launch_files = glob(os.path.join('launch', '*.launch.py'))
+
+# Similarly, gather any configuration files stored directly in a top-level
+# ``config`` directory.
+config_files = glob(os.path.join('config', '*.yaml'))
 
 setup(
     name=package_name,


### PR DESCRIPTION
## Summary
- search for launch files in the package's top-level `launch` directory
- look for config files in a top-level `config` directory

## Testing
- `colcon build` *(fails: command not found)*
- `source install/setup.bash` *(fails: No such file or directory)*
- `ls install/rover_bringup/share/rover_bringup/launch` *(fails: No such file or directory)*
- `ros2 launch rover_bringup rover.launch.py` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b3b7059ecc832bb8b5b86380a27835