### PR TITLE
Add project README with usage and goals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,96 @@
-# autonomous_rover 
+# autonomous_rover
 
-Open source repo for JHU Embodied AI Club.
+Open source ROS 2 stack for the JHU Embodied AI Club focused on an autonomous rover platform.
+This repository is the foundation for a **behavior-tree-based autonomy stack** that builds
+from low-level rover bringup to higher-level navigation and decision-making.
 
+---
 
+## Project Status (Current State)
 
-### usage 
+This repo is a **work in progress** and currently provides:
 
+- **Rover bringup** for the Waveshare UGV stack (hardware interface + state publication).
+- **A minimal Nav2 launch** for planning and control servers.
+- Structure to evolve into a full behavior-tree-driven autonomy stack.
 
+Key packages:
+
+- `rover_bringup`: Launches the core UGV nodes, robot state publisher, and localization.
+- `rover_nav`: Launches a minimal Nav2 stack (controller, planner, BT navigator, costmaps).
+
+---
+
+## Long-Term Goals
+
+This repository is intended to grow into a full **behavior-tree-based autonomy stack** that supports:
+
+- **Full navigation** (map server, localization, recovery behaviors, and planners).
+- **Custom BT nodes** for rover-specific tasks (inspection, patrol, waypoint routines).
+- **Simulation + hardware parity** (Gazebo/Isaac sims with matching launch flows).
+- **Perception integration** (object detection, semantic mapping, and terrain analysis).
+- **Higher-level autonomy** (mission planning, state estimation improvements, teleop fallback).
+
+We welcome contributors who want to help build the system end-to-end—from perception
+and planning to mission logic and deployment.
+
+---
+
+## Usage (Current)
+
+### 1. Pull dependencies
+
+```bash
 vcs import src < ros2.repos
--colcon build
+```
+
+### 2. Build
+
+```bash
+colcon build
+```
+
+### 3. Launch rover bringup (hardware stack)
+
+```bash
+ros2 launch rover_bringup rover.launch.py
+```
+
+Optional RViz:
+
+```bash
+ros2 launch rover_bringup rover.launch.py use_rviz:=true
+```
+
+### 4. Launch Nav2 (minimal)
+
+```bash
+ros2 launch rover_nav nav.launch.py
+```
+
+> Note: The current Nav2 launch is minimal and does **not** include map server or AMCL yet.
+> It assumes localization/odom is already running from bringup.
+
+---
+
+## Media (Add Later)
+
+> **Image placeholder** — insert a rover photo or architecture diagram here.
+
+> **Video placeholder** — insert a demo or simulation clip here.
+
+---
+
+## Contributing
+
+If you're a contributor or recruiter reviewing this repository:
+
+- This is a **foundation repo** with a clear growth path toward full autonomy.
+- We are actively building toward a modular behavior-tree architecture.
+- Contributions to Nav2 integration, BT nodes, simulation, perception, and testing are welcome.
+
+---
+
+## License
+
+TBD


### PR DESCRIPTION
### Motivation

- Provide an informative README as the foundation for a behavior-tree-based autonomy stack to orient contributors and recruiters.
- Capture the current work-in-progress state and give clear, minimal usage instructions for building and launching the repository.

### Description

- Expanded `README.md` with a concise project overview and current status for the JHU Embodied AI Club rover stack.
- Documented key packages (`rover_bringup`, `rover_nav`) and included usage steps for `vcs import`, `colcon build`, and `ros2 launch` commands.
- Added a long-term goals section describing planned behavior-tree nodes, simulation parity, perception integration, and higher-level autonomy features.
- Included placeholders for an image and video and a short contributing note and license placeholder.

### Testing

- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e4f959fe0832b97c44d72c2c29c76)